### PR TITLE
SSP for OpenBSD

### DIFF
--- a/bindings/GNUmakefile
+++ b/bindings/GNUmakefile
@@ -79,7 +79,7 @@ define LINK.bindings
 	@echo "LD $@"
 	$(LD) -r $(LDFLAGS) $^ -o $@
 	@echo "OBJCOPY $@"
-	$(OBJCOPY) -w -G solo5_\* -G _start\* -G __stack_chk_\* $@ $@
+	$(OBJCOPY) -w -G solo5_\* -G _start\* -G $(SSP_GUARD) -G $(SSP_FAIL) $@ $@
 endef
 
 ifdef CONFIG_HVT

--- a/bindings/bindings.h
+++ b/bindings/bindings.h
@@ -52,6 +52,14 @@
 #define STR_EXPAND(y) #y
 #define STR(x) STR_EXPAND(x)
 
+#if defined(__OpenBSD__)
+#define SSP_GUARD __guard_local
+#define SSP_FAIL __stack_smash_handler
+#else
+#define SSP_GUARD __stack_chk_guard
+#define SSP_FAIL __stack_chk_fail
+#endif
+
 /* abort.c */
 void _assert_fail(const char *, const char *, const char *)
     __attribute__((noreturn));

--- a/bindings/crt.c
+++ b/bindings/crt.c
@@ -25,7 +25,7 @@
  * crt_init_early(), keep an easily recognisable "terminator" value here to
  * flag if that did not happen as expected.
  */
-uintptr_t __stack_chk_guard = 0x00deadbeef0d0a00;
+uintptr_t SSP_GUARD = 0x00deadbeef0d0a00;
 
 /*
  * Called by compiler-generated code when corruption of the canary value is
@@ -36,7 +36,7 @@ static const char
 stack_chk_fail_message[] = "Solo5: ABORT: Stack corruption detected\n";
 
 __attribute__((noreturn))
-void __stack_chk_fail(void)
+void SSP_FAIL(void)
 {
     platform_puts(stack_chk_fail_message, sizeof stack_chk_fail_message);
     platform_exit(SOLO5_EXIT_ABORT, NULL);

--- a/bindings/crt_init.h
+++ b/bindings/crt_init.h
@@ -18,7 +18,7 @@
  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-extern uintptr_t __stack_chk_guard;
+extern uintptr_t SSP_GUARD;
 
 #if defined(__x86_64__)
 #define READ_CPU_TICKS cpu_rdtsc
@@ -77,6 +77,6 @@ __attribute__((always_inline)) static inline void crt_init_ssp(void)
     /*
      * Initialise the stack canary value.
      */
-    __stack_chk_guard = READ_CPU_TICKS() + (READ_CPU_TICKS() << 32UL);
-    __stack_chk_guard &= ~(uintptr_t)0xff00;
+    SSP_GUARD = READ_CPU_TICKS() + (READ_CPU_TICKS() << 32UL);
+    SSP_GUARD &= ~(uintptr_t)0xff00;
 }

--- a/bindings/genode/bindings.cc
+++ b/bindings/genode/bindings.cc
@@ -54,10 +54,10 @@ namespace Solo5 {
  * Naive SSP implementation
  */
 extern "C" {
-	Genode::addr_t __stack_chk_guard;
+	Genode::addr_t SSP_GUARD;
 
 	extern "C" __attribute__((noreturn))
-	void __stack_chk_fail (void)
+	void SSP_FAIL (void)
 	{
 		Genode::error("stack smashing detected");
 		solo5_abort();
@@ -595,7 +595,7 @@ void Component::construct(Genode::Env &env)
 	 * set a new stack canary, this is possible
 	 * because this procedure never returns
 	 */
-	__stack_chk_guard = generate_canary(inst.heap);
+	SSP_GUARD = generate_canary(inst.heap);
 
 	/* block for application then exit */
 	env.parent().exit(solo5_app_main(&si));

--- a/bindings/genode/stubs.c
+++ b/bindings/genode/stubs.c
@@ -16,5 +16,5 @@ void solo5_block_info(struct solo5_block_info *info) { }
 solo5_result_t solo5_block_write(solo5_off_t offset, const uint8_t *buf, size_t size) { return SOLO5_R_EUNSPEC; }
 solo5_result_t solo5_block_read(solo5_off_t offset, uint8_t *buf, size_t size) { return SOLO5_R_EUNSPEC; }
 
-uintptr_t __stack_chk_guard;
-void __stack_chk_fail (void) { }
+uintptr_t SSP_GUARD;
+void SSP_FAIL (void) { }


### PR DESCRIPTION
rename

- `__stack_chk_guard` to `__guard_local `

- `__stack_chk_fail` to `__stack_smash_handler `

tweak bindings/GNUMakefile to use the new names

I think it works

```
$ doas tenders/hvt/solo5-hvt tests/test_ssp/test_ssp.hvt
            |      ___|
  __|  _ \  |  _ \ __ \
\__ \ (   | | (   |  ) |
____/\___/ _|\___/____/
Solo5: Memory map: 512 MB addressable:
Solo5:   reserved @ (0x0 - 0xfffff)
Solo5:       text @ (0x100000 - 0x105fff)
Solo5:     rodata @ (0x106000 - 0x106fff)
Solo5:       data @ (0x107000 - 0x10bfff)
Solo5:       heap >= 0x10c000 < stack < 0x20000000

**** Solo5 standalone test_ssp ****

1234567890123456789012345678901234567890
Solo5: ABORT: Stack corruption detected
```

Would have a clue how to reconcile this for Linux and FreeBSD tho.